### PR TITLE
[0.1] Ingore circleci while exporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text=auto
 
+/.circleci export-ignore
 /.github export-ignore
 /tests export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION

# About

The `.circleci` directory shouldn't be contained in the downloaded dist.